### PR TITLE
feat: add separate_packages option

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -11,10 +11,10 @@ profiles](https://pycqa.github.io/isort/docs/configuration/profiles.html).
 
 Tells isort to set the known standard library based on the specified Python version. Default is to assume any Python 3 version could be the target, and use a union of all stdlib modules across versions. If auto is specified, the version of the interpreter used to run isort (currently: 39) will be used.
 
-**Type:** String  
-**Default:** `py3`  
-**Config default:** `3`  
-**Python & Config File Name:** py_version  
+**Type:** String
+**Default:** `py3`
+**Config default:** `3`
+**Python & Config File Name:** py_version
 **CLI Flags:**
 
 - --py
@@ -46,10 +46,10 @@ py_version=39
 
 Force specific imports to the top of their appropriate section.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** force_to_top  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** force_to_top
 **CLI Flags:**
 
 - -t
@@ -59,10 +59,10 @@ Force specific imports to the top of their appropriate section.
 
 Files that isort should skip over. If you want to skip multiple files you should specify twice: `--skip file1 --skip file2`. Values can be file names, directory names or file paths. To skip all files in a nested path, use [`--skip-glob`](#skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings  
-**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.pytype' '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`  
-**Config default:** `['.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv']`  
-**Python & Config File Name:** skip  
+**Type:** List of Strings
+**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.pytype' '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`
+**Config default:** `['.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv']`
+**Python & Config File Name:** skip
 **CLI Flags:**
 
 - -s
@@ -89,10 +89,10 @@ skip = [".gitignore", ".dockerignore"]
 
 Extends --skip to add additional files that isort should skip over. If you want to skip multiple files you should specify twice: --skip file1 --skip file2. Values can be file names, directory names or file paths. To skip all files in a nested path, use [`--skip-glob`](#skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** extend_skip  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** extend_skip
 **CLI Flags:**
 
 - --extend-skip
@@ -118,10 +118,10 @@ extend_skip = [".md", ".json"]
 
 Files that isort should skip over. To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** skip_glob  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** skip_glob
 **CLI Flags:**
 
 - --sg
@@ -149,10 +149,10 @@ skip_glob = ["docs/*"]
 
 Additional files that isort should skip over (extending --skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** extend_skip_glob  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** extend_skip_glob
 **CLI Flags:**
 
 - --extend-skip-glob
@@ -181,10 +181,10 @@ Treat project as a git repository and ignore files listed in .gitignore. To even
 
 NOTE: This requires git to be installed and accessible from the same shell as isort.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** skip_gitignore  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** skip_gitignore
 **CLI Flags:**
 
 - --gitignore
@@ -194,10 +194,10 @@ NOTE: This requires git to be installed and accessible from the same shell as is
 
 The max length of an import line (used for wrapping long imports).
 
-**Type:** Int  
-**Default:** `79`  
-**Config default:** `79`  
-**Python & Config File Name:** line_length  
+**Type:** Int
+**Default:** `79`
+**Config default:** `79`
+**Python & Config File Name:** line_length
 **CLI Flags:**
 
 - -l
@@ -210,10 +210,10 @@ The max length of an import line (used for wrapping long imports).
 Specifies how long lines that are wrapped should be, if not set line_length is used.
 NOTE: wrap_length must be LOWER than or equal to line_length.
 
-**Type:** Int  
-**Default:** `0`  
-**Config default:** `0`  
-**Python & Config File Name:** wrap_length  
+**Type:** Int
+**Default:** `0`
+**Config default:** `0`
+**Python & Config File Name:** wrap_length
 **CLI Flags:**
 
 - --wl
@@ -223,10 +223,10 @@ NOTE: wrap_length must be LOWER than or equal to line_length.
 
 Forces line endings to the specified value. If not set, values will be guessed per-file.
 
-**Type:** String  
-**Default:** ` `  
-**Config default:** ` `  
-**Python & Config File Name:** line_ending  
+**Type:** String
+**Default:** ` `
+**Config default:** ` `
+**Python & Config File Name:** line_ending
 **CLI Flags:**
 
 - --le
@@ -236,10 +236,10 @@ Forces line endings to the specified value. If not set, values will be guessed p
 
 Specifies whether to sort re-exports (`__all__` collections) automatically.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** sort_reexports  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** sort_reexports
 **CLI Flags:**
 
 - --srx
@@ -249,20 +249,20 @@ Specifies whether to sort re-exports (`__all__` collections) automatically.
 
 What sections isort should display imports for and in what order
 
-**Type:** List of Strings  
-**Default:** `('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')`  
-**Config default:** `['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']`  
-**Python & Config File Name:** sections  
+**Type:** List of Strings
+**Default:** `('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')`
+**Config default:** `['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']`
+**Python & Config File Name:** sections
 **CLI Flags:** **Not Supported**
 
 ## No Sections
 
 Put all imports into the same section bucket
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** no_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** no_sections
 **CLI Flags:**
 
 - --ds
@@ -272,10 +272,10 @@ Put all imports into the same section bucket
 
 Force isort to recognize a module as part of Python's internal future compatibility libraries. WARNING: this overrides the behavior of __future__ handling and therefore can result in code that can't execute. If you're looking to add dependencies such as six, a better option is to create another section below --future using custom sections. See: https://github.com/PyCQA/isort#custom-sections-and-ordering and the discussion here: https://github.com/PyCQA/isort/issues/1463.
 
-**Type:** List of Strings  
-**Default:** `('__future__',)`  
-**Config default:** `['__future__']`  
-**Python & Config File Name:** known_future_library  
+**Type:** List of Strings
+**Default:** `('__future__',)`
+**Config default:** `['__future__']`
+**Python & Config File Name:** known_future_library
 **CLI Flags:**
 
 - -f
@@ -285,10 +285,10 @@ Force isort to recognize a module as part of Python's internal future compatibil
 
 Force isort to recognize a module as being part of a third party library.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** known_third_party  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** known_third_party
 **CLI Flags:**
 
 - -o
@@ -316,10 +316,10 @@ known_third_party = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as being part of the current python project.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** known_first_party  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** known_first_party
 **CLI Flags:**
 
 - -p
@@ -347,10 +347,10 @@ known_first_party = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as being a local folder. Generally, this is reserved for relative imports (from . import module).
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** known_local_folder  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** known_local_folder
 **CLI Flags:**
 
 - --known-local-folder
@@ -377,10 +377,10 @@ known_local_folder = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as part of Python's standard library.
 
-**Type:** List of Strings  
-**Default:** `('_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo')`  
-**Config default:** `['_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo']`  
-**Python & Config File Name:** known_standard_library  
+**Type:** List of Strings
+**Default:** `('_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo')`
+**Config default:** `['_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo']`
+**Python & Config File Name:** known_standard_library
 **CLI Flags:**
 
 - -b
@@ -408,10 +408,10 @@ known_standard_library = ["my_module1", "my_module2"]
 
 Extra modules to be included in the list of ones in Python's standard library.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** extra_standard_library  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** extra_standard_library
 **CLI Flags:**
 
 - --extra-builtin
@@ -438,10 +438,10 @@ extra_standard_library = ["my_module1", "my_module2"]
 
 known_OTHER is how imports of custom sections are defined. OTHER is a placeholder for the custom section name.
 
-**Type:** Dict  
-**Default:** `{}`  
-**Config default:** `{}`  
-**Python & Config File Name:** known_other  
+**Type:** Dict
+**Default:** `{}`
+**Config default:** `{}`
+**Python & Config File Name:** known_other
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -466,10 +466,10 @@ known_airflow = ['airflow']
 
 Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-grid, 5-vert-grid-grouped, 6-deprecated-alias-for-5, 7-noqa, 8-vertical-hanging-indent-bracket, 9-vertical-prefix-from-module-import, 10-hanging-indent-with-parentheses).
 
-**Type:** Wrapmodes  
-**Default:** `WrapModes.GRID`  
-**Config default:** `WrapModes.GRID`  
-**Python & Config File Name:** multi_line_output  
+**Type:** Wrapmodes
+**Default:** `WrapModes.GRID`
+**Config default:** `WrapModes.GRID`
+**Python & Config File Name:** multi_line_output
 **CLI Flags:**
 
 - -m
@@ -495,10 +495,10 @@ multi_line_output = 3
 
 Force certain sub modules to show separately
 
-**Type:** List of Strings  
-**Default:** `()`  
-**Config default:** `[]`  
-**Python & Config File Name:** forced_separate  
+**Type:** List of Strings
+**Default:** `()`
+**Config default:** `[]`
+**Python & Config File Name:** forced_separate
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -523,10 +523,10 @@ forced_separate = ["glob_exp1", "glob_exp2"]
 
 String to place for indents defaults to "    " (4 spaces).
 
-**Type:** String  
-**Default:** `    `  
-**Config default:** `    `  
-**Python & Config File Name:** indent  
+**Type:** String
+**Default:** `    `
+**Config default:** `    `
+**Python & Config File Name:** indent
 **CLI Flags:**
 
 - -i
@@ -536,20 +536,20 @@ String to place for indents defaults to "    " (4 spaces).
 
 Allows customizing how isort prefixes comments that it adds or modifies on import linesGenerally `  #` (two spaces before a pound symbol) is use, though one space is also common.
 
-**Type:** String  
-**Default:** `  #`  
-**Config default:** `  #`  
-**Python & Config File Name:** comment_prefix  
+**Type:** String
+**Default:** `  #`
+**Config default:** `  #`
+**Python & Config File Name:** comment_prefix
 **CLI Flags:** **Not Supported**
 
 ## Length Sort
 
 Sort imports by their string length.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** length_sort  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** length_sort
 **CLI Flags:**
 
 - --ls
@@ -559,10 +559,10 @@ Sort imports by their string length.
 
 Sort straight imports by their string length. Similar to `length_sort` but applies only to straight imports and doesn't affect from imports.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** length_sort_straight  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** length_sort_straight
 **CLI Flags:**
 
 - --lss
@@ -572,10 +572,10 @@ Sort straight imports by their string length. Similar to `length_sort` but appli
 
 Sort the given sections by length
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** length_sort_sections  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** length_sort_sections
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -600,10 +600,10 @@ length_sort_sections = ["future", "stdlib"]
 
 Adds the specified import line to all files, automatically determining correct placement.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** add_imports  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** add_imports
 **CLI Flags:**
 
 - -a
@@ -631,10 +631,10 @@ add_imports = ["import os", "import json"]
 
 Removes the specified import from all files.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** remove_imports  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** remove_imports
 **CLI Flags:**
 
 - --rm
@@ -662,10 +662,10 @@ remove_imports = ["os", "json"]
 
 Only adds the imports specified in --add-import if the file contains existing imports.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** append_only  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** append_only
 **CLI Flags:**
 
 - --append
@@ -675,10 +675,10 @@ Only adds the imports specified in --add-import if the file contains existing im
 
 Reverse order of relative imports.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** reverse_relative  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** reverse_relative
 **CLI Flags:**
 
 - --rr
@@ -688,10 +688,10 @@ Reverse order of relative imports.
 
 Forces all from imports to appear on their own line
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** force_single_line  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** force_single_line
 **CLI Flags:**
 
 - --sl
@@ -701,10 +701,10 @@ Forces all from imports to appear on their own line
 
 One or more modules to exclude from the single line rule.
 
-**Type:** List of Strings  
-**Default:** `()`  
-**Config default:** `[]`  
-**Python & Config File Name:** single_line_exclusions  
+**Type:** List of Strings
+**Default:** `()`
+**Config default:** `[]`
+**Python & Config File Name:** single_line_exclusions
 **CLI Flags:**
 
 - --nsl
@@ -732,10 +732,10 @@ single_line_exclusions = ["os", "json"]
 
 Sets the default section for import options: ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')
 
-**Type:** String  
-**Default:** `THIRDPARTY`  
-**Config default:** `THIRDPARTY`  
-**Python & Config File Name:** default_section  
+**Type:** String
+**Default:** `THIRDPARTY`
+**Config default:** `THIRDPARTY`
+**Python & Config File Name:** default_section
 **CLI Flags:**
 
 - --sd
@@ -745,30 +745,30 @@ Sets the default section for import options: ('FUTURE', 'STDLIB', 'THIRDPARTY', 
 
 A mapping of import sections to import heading comments that should show above them.
 
-**Type:** Dict  
-**Default:** `{}`  
-**Config default:** `{}`  
-**Python & Config File Name:** import_headings  
+**Type:** Dict
+**Default:** `{}`
+**Config default:** `{}`
+**Python & Config File Name:** import_headings
 **CLI Flags:** **Not Supported**
 
 ## Import Footers
 
 A mapping of import sections to import footer comments that should show below them.
 
-**Type:** Dict  
-**Default:** `{}`  
-**Config default:** `{}`  
-**Python & Config File Name:** import_footers  
+**Type:** Dict
+**Default:** `{}`
+**Config default:** `{}`
+**Python & Config File Name:** import_footers
 **CLI Flags:** **Not Supported**
 
 ## Balanced Wrapping
 
 Balances wrapping to produce the most consistent line length possible
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** balanced_wrapping  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** balanced_wrapping
 **CLI Flags:**
 
 - -e
@@ -778,10 +778,10 @@ Balances wrapping to produce the most consistent line length possible
 
 Use parentheses for line continuation on length limit instead of backslashes. **NOTE**: This is separate from wrap modes, and only affects how individual lines that  are too long get continued, not sections of multiple imports.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** use_parentheses  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** use_parentheses
 **CLI Flags:**
 
 - --up
@@ -794,10 +794,10 @@ Order imports by type, which is determined by case, in addition to alphabeticall
 **NOTE**: type here refers to the implied type from the import name capitalization.
  isort does not do type introspection for the imports. These "types" are simply: CONSTANT_VARIABLE, CamelCaseClass, variable_or_function. If your project follows PEP8 or a related coding standard and has many imports this is a good default, otherwise you likely will want to turn it off. From the CLI the `--dont-order-by-type` option will turn this off.
 
-**Type:** Bool  
-**Default:** `True`  
-**Config default:** `true`  
-**Python & Config File Name:** order_by_type  
+**Type:** Bool
+**Default:** `True`
+**Config default:** `true`
+**Python & Config File Name:** order_by_type
 **CLI Flags:**
 
 - --ot
@@ -807,10 +807,10 @@ Order imports by type, which is determined by case, in addition to alphabeticall
 
 Ensures the output doesn't save if the resulting file contains syntax errors.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** atomic  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** atomic
 **CLI Flags:**
 
 - --ac
@@ -820,10 +820,10 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 
 The number of blank lines to place before imports. -1 for automatic determination
 
-**Type:** Int  
-**Default:** `-1`  
-**Config default:** `-1`  
-**Python & Config File Name:** lines_before_imports  
+**Type:** Int
+**Default:** `-1`
+**Config default:** `-1`
+**Python & Config File Name:** lines_before_imports
 **CLI Flags:**
 
 - --lbi
@@ -833,10 +833,10 @@ The number of blank lines to place before imports. -1 for automatic determinatio
 
 The number of blank lines to place after imports. -1 for automatic determination
 
-**Type:** Int  
-**Default:** `-1`  
-**Config default:** `-1`  
-**Python & Config File Name:** lines_after_imports  
+**Type:** Int
+**Default:** `-1`
+**Config default:** `-1`
+**Python & Config File Name:** lines_after_imports
 **CLI Flags:**
 
 - --lai
@@ -846,20 +846,20 @@ The number of blank lines to place after imports. -1 for automatic determination
 
 The number of lines to place between sections
 
-**Type:** Int  
-**Default:** `1`  
-**Config default:** `1`  
-**Python & Config File Name:** lines_between_sections  
+**Type:** Int
+**Default:** `1`
+**Config default:** `1`
+**Python & Config File Name:** lines_between_sections
 **CLI Flags:** **Not Supported**
 
 ## Lines Between Types
 
 The number of lines to place between direct and from imports
 
-**Type:** Int  
-**Default:** `0`  
-**Config default:** `0`  
-**Python & Config File Name:** lines_between_types  
+**Type:** Int
+**Default:** `0`
+**Config default:** `0`
+**Python & Config File Name:** lines_between_types
 **CLI Flags:**
 
 - --lbt
@@ -869,10 +869,10 @@ The number of lines to place between direct and from imports
 
 Combines as imports on the same line.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** combine_as_imports  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** combine_as_imports
 **CLI Flags:**
 
 - --ca
@@ -882,10 +882,10 @@ Combines as imports on the same line.
 
 Ensures that if a star import is present, nothing else is imported from that namespace.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** combine_star  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** combine_star
 **CLI Flags:**
 
 - --cs
@@ -895,10 +895,10 @@ Ensures that if a star import is present, nothing else is imported from that nam
 
 Includes a trailing comma on multi line imports that include parentheses.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** include_trailing_comma  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** include_trailing_comma
 **CLI Flags:**
 
 - --tc
@@ -907,10 +907,10 @@ Includes a trailing comma on multi line imports that include parentheses.
 
 Split imports list followed by a trailing comma into VERTICAL_HANGING_INDENT mode. This follows Black style magic comma.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** split_on_trailing_comma  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** split_on_trailing_comma
 **CLI Flags:**
 
 - --split-on-trailing-comma
@@ -919,10 +919,10 @@ Split imports list followed by a trailing comma into VERTICAL_HANGING_INDENT mod
 
 Switches the typical ordering preference, showing from imports first then straight ones.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** from_first  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** from_first
 **CLI Flags:**
 
 - --ff
@@ -932,10 +932,10 @@ Switches the typical ordering preference, showing from imports first then straig
 
 Shows verbose output, such as when files are skipped or when a check is successful.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** verbose  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** verbose
 **CLI Flags:**
 
 - -v
@@ -945,10 +945,10 @@ Shows verbose output, such as when files are skipped or when a check is successf
 
 Shows extra quiet output, only errors are outputted.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** quiet  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** quiet
 **CLI Flags:**
 
 - -q
@@ -958,10 +958,10 @@ Shows extra quiet output, only errors are outputted.
 
 Forces import adds even if the original file is empty.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** force_adds  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** force_adds
 **CLI Flags:**
 
 - --af
@@ -971,10 +971,10 @@ Forces import adds even if the original file is empty.
 
 Force all imports to be sorted alphabetically within a section
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** force_alphabetical_sort_within_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** force_alphabetical_sort_within_sections
 **CLI Flags:**
 
 - --fass
@@ -984,10 +984,10 @@ Force all imports to be sorted alphabetically within a section
 
 Force all imports to be sorted as a single section
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** force_alphabetical_sort  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** force_alphabetical_sort
 **CLI Flags:**
 
 - --fas
@@ -997,10 +997,10 @@ Force all imports to be sorted as a single section
 
 Force number of from imports (defaults to 2 when passed as CLI flag without value) to be grid wrapped regardless of line length. If 0 is passed in (the global default) only line length is considered.
 
-**Type:** Int  
-**Default:** `0`  
-**Config default:** `0`  
-**Python & Config File Name:** force_grid_wrap  
+**Type:** Int
+**Default:** `0`
+**Config default:** `0`
+**Python & Config File Name:** force_grid_wrap
 **CLI Flags:**
 
 - --fgw
@@ -1010,10 +1010,10 @@ Force number of from imports (defaults to 2 when passed as CLI flag without valu
 
 Don't sort straight-style imports (like import sys) before from-style imports (like from itertools import groupby). Instead, sort the imports by module, independent of import style.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** force_sort_within_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** force_sort_within_sections
 **CLI Flags:**
 
 - --fss
@@ -1023,30 +1023,40 @@ Don't sort straight-style imports (like import sys) before from-style imports (l
 
 Lexicographical order is strictly alphabetical order. For example by default isort will sort `1, 10, 2` into `1, 2, 10` - but with lexicographical sorting enabled it will remain `1, 10, 2`.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** lexicographical  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** lexicographical
 **CLI Flags:** **Not Supported**
 
 ## Group By Package
 
 If `True` isort will automatically create section groups by the top-level package they come from.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** group_by_package  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** group_by_package
+**CLI Flags:** **Not Supported**
+
+## Separate Top-Level Packages
+
+Separate top-level packages with newlines.
+
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** separate_top_level_packages
 **CLI Flags:** **Not Supported**
 
 ## Ignore Whitespace
 
 Tells isort to ignore whitespace differences when --check-only is being used.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** ignore_whitespace  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** ignore_whitespace
 **CLI Flags:**
 
 - --ws
@@ -1056,10 +1066,10 @@ Tells isort to ignore whitespace differences when --check-only is being used.
 
 Sections which should not be split with previous by empty lines
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** no_lines_before  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** no_lines_before
 **CLI Flags:**
 
 - --nlb
@@ -1087,10 +1097,10 @@ no_lines_before = ["future", "stdlib"]
 
 Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c ,b`).
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** no_inline_sort  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** no_inline_sort
 **CLI Flags:**
 
 - --nis
@@ -1100,20 +1110,20 @@ Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c 
 
 If enabled, isort will strip comments that exist within import lines.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** ignore_comments  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** ignore_comments
 **CLI Flags:** **Not Supported**
 
 ## Case Sensitive
 
 Tells isort to include casing when sorting module names
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** case_sensitive  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** case_sensitive
 **CLI Flags:**
 
 - --case-sensitive
@@ -1122,10 +1132,10 @@ Tells isort to include casing when sorting module names
 
 Virtual environment to use for determining whether a package is third-party
 
-**Type:** String  
-**Default:** ` `  
-**Config default:** ` `  
-**Python & Config File Name:** virtual_env  
+**Type:** String
+**Default:** ` `
+**Config default:** ` `
+**Python & Config File Name:** virtual_env
 **CLI Flags:**
 
 - --virtual-env
@@ -1134,10 +1144,10 @@ Virtual environment to use for determining whether a package is third-party
 
 Conda environment to use for determining whether a package is third-party
 
-**Type:** String  
-**Default:** ` `  
-**Config default:** ` `  
-**Python & Config File Name:** conda_env  
+**Type:** String
+**Default:** ` `
+**Config default:** ` `
+**Python & Config File Name:** conda_env
 **CLI Flags:**
 
 - --conda-env
@@ -1146,10 +1156,10 @@ Conda environment to use for determining whether a package is third-party
 
 Inserts a blank line before a comment following an import.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** ensure_newline_before_comments  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** ensure_newline_before_comments
 **CLI Flags:**
 
 - -n
@@ -1162,10 +1172,10 @@ pycharm, google, open\_stack, plone, attrs, hug, wemake, appnexus. As well as
 any [shared
 profiles](https://pycqa.github.io/isort/docs/howto/shared_profiles.html).
 
-**Type:** String  
-**Default:** ` `  
-**Config default:** ` `  
-**Python & Config File Name:** profile  
+**Type:** String
+**Default:** ` `
+**Config default:** ` `
+**Python & Config File Name:** profile
 **CLI Flags:**
 
 - --profile
@@ -1174,10 +1184,10 @@ profiles](https://pycqa.github.io/isort/docs/howto/shared_profiles.html).
 
 Tells isort to honor noqa comments to enforce skipping those comments.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** honor_noqa  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** honor_noqa
 **CLI Flags:**
 
 - --honor-noqa
@@ -1186,10 +1196,10 @@ Tells isort to honor noqa comments to enforce skipping those comments.
 
 Add an explicitly defined source path (modules within src paths have their imports automatically categorized as first_party). Glob expansion (`*` and `**`) is supported for this option.
 
-**Type:** List of Strings  
-**Default:** `()`  
-**Config default:** `[]`  
-**Python & Config File Name:** src_paths  
+**Type:** List of Strings
+**Default:** `()`
+**Config default:** `[]`
+**Python & Config File Name:** src_paths
 **CLI Flags:**
 
 - --src
@@ -1217,10 +1227,10 @@ src_paths = ["src", "tests"]
 
 Use the old deprecated finder logic that relies on environment introspection magic.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** old_finders  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** old_finders
 **CLI Flags:**
 
 - --old-finders
@@ -1230,10 +1240,10 @@ Use the old deprecated finder logic that relies on environment introspection mag
 
 Tells isort to remove redundant aliases from imports, such as `import os as os`. This defaults to `False` simply because some projects use these seemingly useless  aliases to signify intent and change behaviour.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** remove_redundant_aliases  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** remove_redundant_aliases
 **CLI Flags:**
 
 - --remove-redundant-aliases
@@ -1245,10 +1255,10 @@ This can be an excellent shortcut for collecting imports every once in a while w
 
 *NOTE*: It currently doesn't work with cimports and introduces some extra over-head and a performance penalty.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** float_to_top  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** float_to_top
 **CLI Flags:**
 
 - --float-to-top
@@ -1257,10 +1267,10 @@ This can be an excellent shortcut for collecting imports every once in a while w
 
 Tells isort to filter files even when they are explicitly passed in as part of the CLI command.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** filter_files  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** filter_files
 **CLI Flags:**
 
 - --filter-files
@@ -1269,10 +1279,10 @@ Tells isort to filter files even when they are explicitly passed in as part of t
 
 Specifies the name of a formatting plugin to use when producing output.
 
-**Type:** String  
-**Default:** ` `  
-**Config default:** ` `  
-**Python & Config File Name:** formatter  
+**Type:** String
+**Default:** ` `
+**Config default:** ` `
+**Python & Config File Name:** formatter
 **CLI Flags:**
 
 - --formatter
@@ -1281,20 +1291,20 @@ Specifies the name of a formatting plugin to use when producing output.
 
 The fully qualified Python path of a function to apply to format code sorted by isort.
 
-**Type:** Nonetype  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** formatting_function  
+**Type:** Nonetype
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** formatting_function
 **CLI Flags:** **Not Supported**
 
 ## Color Output
 
 Tells isort to use color in terminal output.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** color_output  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** color_output
 **CLI Flags:**
 
 - --color
@@ -1303,10 +1313,10 @@ Tells isort to use color in terminal output.
 
 Tells isort to treat the specified single line comment(s) as if they are code.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** treat_comments_as_code  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** treat_comments_as_code
 **CLI Flags:**
 
 - --treat-comment-as-code
@@ -1333,10 +1343,10 @@ treat_comments_as_code = ["# my comment 1", "# my other comment"]
 
 Tells isort to treat all single line comments as if they are code.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** treat_all_comments_as_code  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** treat_all_comments_as_code
 **CLI Flags:**
 
 - --treat-all-comment-as-code
@@ -1345,10 +1355,10 @@ Tells isort to treat all single line comments as if they are code.
 
 Specifies what extensions isort can be run against.
 
-**Type:** List of Strings  
-**Default:** `('pxd', 'py', 'pyi', 'pyx')`  
-**Config default:** `['pxd', 'py', 'pyi', 'pyx']`  
-**Python & Config File Name:** supported_extensions  
+**Type:** List of Strings
+**Default:** `('pxd', 'py', 'pyi', 'pyx')`
+**Config default:** `['pxd', 'py', 'pyi', 'pyx']`
+**Python & Config File Name:** supported_extensions
 **CLI Flags:**
 
 - --ext
@@ -1377,10 +1387,10 @@ supported_extensions = ["pyw", "ext"]
 
 Specifies what extensions isort can never be run against.
 
-**Type:** List of Strings  
-**Default:** `('pex',)`  
-**Config default:** `['pex']`  
-**Python & Config File Name:** blocked_extensions  
+**Type:** List of Strings
+**Default:** `('pex',)`
+**Config default:** `['pex']`
+**Python & Config File Name:** blocked_extensions
 **CLI Flags:**
 
 - --blocked-extension
@@ -1407,40 +1417,40 @@ blocked_extensions = ["pyw", "pyc"]
 
 An override list of tokens to always recognize as a CONSTANT for order_by_type regardless of casing.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** constants  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** constants
 **CLI Flags:** **Not Supported**
 
 ## Classes
 
 An override list of tokens to always recognize as a Class for order_by_type regardless of casing.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** classes  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** classes
 **CLI Flags:** **Not Supported**
 
 ## Variables
 
 An override list of tokens to always recognize as a var for order_by_type regardless of casing.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** variables  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** variables
 **CLI Flags:** **Not Supported**
 
 ## Dedup Headings
 
 Tells isort to only show an identical custom import heading comment once, even if there are multiple sections with the comment set.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** dedup_headings  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** dedup_headings
 **CLI Flags:**
 
 - --dedup-headings
@@ -1449,10 +1459,10 @@ Tells isort to only show an identical custom import heading comment once, even i
 
 Causes imports to be sorted based on their sections like STDLIB, THIRDPARTY, etc. Within sections, the imports are ordered by their import style and the imports with the same style maintain their relative positions.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** only_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** only_sections
 **CLI Flags:**
 
 - --only-sections
@@ -1462,10 +1472,10 @@ Causes imports to be sorted based on their sections like STDLIB, THIRDPARTY, etc
 
 Suppresses verbose output for non-modified files.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** only_modified  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** only_modified
 **CLI Flags:**
 
 - --only-modified
@@ -1475,10 +1485,10 @@ Suppresses verbose output for non-modified files.
 
 Combines all the bare straight imports of the same section in a single line. Won't work with sections which have 'as' imports
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** combine_straight_imports  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** combine_straight_imports
 **CLI Flags:**
 
 - --combine-straight-imports
@@ -1488,50 +1498,50 @@ Combines all the bare straight imports of the same section in a single line. Won
 
 Automatically determine local namespace packages, generally by lack of any src files before a src containing directory.
 
-**Type:** Bool  
-**Default:** `True`  
-**Config default:** `true`  
-**Python & Config File Name:** auto_identify_namespace_packages  
+**Type:** Bool
+**Default:** `True`
+**Config default:** `true`
+**Python & Config File Name:** auto_identify_namespace_packages
 **CLI Flags:** **Not Supported**
 
 ## Namespace Packages
 
 Manually specify one or more namespace packages.
 
-**Type:** List of Strings  
-**Default:** `frozenset()`  
-**Config default:** `[]`  
-**Python & Config File Name:** namespace_packages  
+**Type:** List of Strings
+**Default:** `frozenset()`
+**Config default:** `[]`
+**Python & Config File Name:** namespace_packages
 **CLI Flags:** **Not Supported**
 
 ## Follow Links
 
 If `True` isort will follow symbolic links when doing recursive sorting.
 
-**Type:** Bool  
-**Default:** `True`  
-**Config default:** `true`  
-**Python & Config File Name:** follow_links  
+**Type:** Bool
+**Default:** `True`
+**Config default:** `true`
+**Python & Config File Name:** follow_links
 **CLI Flags:** **Not Supported**
 
 ## Indented Import Headings
 
 If `True` isort will apply import headings to indented imports the same way it does unindented ones.
 
-**Type:** Bool  
-**Default:** `True`  
-**Config default:** `true`  
-**Python & Config File Name:** indented_import_headings  
+**Type:** Bool
+**Default:** `True`
+**Config default:** `true`
+**Python & Config File Name:** indented_import_headings
 **CLI Flags:** **Not Supported**
 
 ## Honor Case In Force Sorted Sections
 
 Honor `--case-sensitive` when `--force-sort-within-sections` is being used. Without this option set, `--order-by-type` decides module name ordering too.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** honor_case_in_force_sorted_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** honor_case_in_force_sorted_sections
 **CLI Flags:**
 
 - --hcss
@@ -1541,10 +1551,10 @@ Honor `--case-sensitive` when `--force-sort-within-sections` is being used. With
 
 When using `--force-sort-within-sections`, sort relative imports the same way as they are sorted when not using that setting.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** sort_relative_in_force_sorted_sections  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** sort_relative_in_force_sorted_sections
 **CLI Flags:**
 
 - --srss
@@ -1554,10 +1564,10 @@ When using `--force-sort-within-sections`, sort relative imports the same way as
 
 Tells isort to overwrite in place using the same file handle. Comes at a performance and memory usage penalty over its standard approach but ensures all file flags and modes stay unchanged.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** overwrite_in_place  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** overwrite_in_place
 **CLI Flags:**
 
 - --overwrite-in-place
@@ -1566,10 +1576,10 @@ Tells isort to overwrite in place using the same file handle. Comes at a perform
 
 Reverses the ordering of imports.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** reverse_sort  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** reverse_sort
 **CLI Flags:**
 
 - --reverse-sort
@@ -1578,10 +1588,10 @@ Reverses the ordering of imports.
 
 Forces star imports above others to avoid overriding directly imported variables.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** star_first  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** star_first
 **CLI Flags:**
 
 - --star-first
@@ -1590,20 +1600,20 @@ Forces star imports above others to avoid overriding directly imported variables
 
 If `True` isort will honor ignores within locally defined .git_ignore files.
 
-**Type:** Dict  
-**Default:** `{}`  
-**Config default:** `{}`  
-**Python & Config File Name:** git_ignore  
+**Type:** Dict
+**Default:** `{}`
+**Config default:** `{}`
+**Python & Config File Name:** git_ignore
 **CLI Flags:** **Not Supported**
 
 ## Format Error
 
 Override the format used to print errors.
 
-**Type:** String  
-**Default:** `{error}: {message}`  
-**Config default:** `{error}: {message}`  
-**Python & Config File Name:** format_error  
+**Type:** String
+**Default:** `{error}: {message}`
+**Config default:** `{error}: {message}`
+**Python & Config File Name:** format_error
 **CLI Flags:**
 
 - --format-error
@@ -1612,10 +1622,10 @@ Override the format used to print errors.
 
 Override the format used to print success.
 
-**Type:** String  
-**Default:** `{success}: {message}`  
-**Config default:** `{success}: {message}`  
-**Python & Config File Name:** format_success  
+**Type:** String
+**Default:** `{success}: {message}`
+**Config default:** `{success}: {message}`
+**Python & Config File Name:** format_success
 **CLI Flags:**
 
 - --format-success
@@ -1624,10 +1634,10 @@ Override the format used to print success.
 
 Specify sorting function. Can be built in (natural[default] = force numbers to be sequential, native = Python's built-in sorted function) or an installable plugin.
 
-**Type:** String  
-**Default:** `natural`  
-**Config default:** `natural`  
-**Python & Config File Name:** sort_order  
+**Type:** String
+**Default:** `natural`
+**Config default:** `natural`
+**Python & Config File Name:** sort_order
 **CLI Flags:**
 
 - --sort-order
@@ -1636,10 +1646,10 @@ Specify sorting function. Can be built in (natural[default] = force numbers to b
 
 Displays the currently installed version of isort.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - -V
@@ -1655,10 +1665,10 @@ Displays the currently installed version of isort.
 
 Returns just the current version number without the logo
 
-**Type:** String  
-**Default:** `==SUPPRESS==`  
-**Config default:** `==SUPPRESS==`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `==SUPPRESS==`
+**Config default:** `==SUPPRESS==`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --vn
@@ -1668,10 +1678,10 @@ Returns just the current version number without the logo
 
 Force resulting output to stdout, instead of in-place.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - -d
@@ -1681,10 +1691,10 @@ Force resulting output to stdout, instead of in-place.
 
 See isort's determined config, as well as sources of config options.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --show-config
@@ -1693,10 +1703,10 @@ See isort's determined config, as well as sources of config options.
 
 See the files isort will be run against with the current config options.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --show-files
@@ -1705,10 +1715,10 @@ See the files isort will be run against with the current config options.
 
 Prints a diff of all the changes isort would make to a file, instead of changing it in place
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --df
@@ -1718,10 +1728,10 @@ Prints a diff of all the changes isort would make to a file, instead of changing
 
 Checks the file for unsorted / unformatted imports and prints them to the command line without modifying the file. Returns 0 when nothing would change and returns 1 when the file would be reformatted.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - -c
@@ -1732,10 +1742,10 @@ Checks the file for unsorted / unformatted imports and prints them to the comman
 
 Explicitly set the settings path or file instead of auto determining based on file location.
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --sp
@@ -1747,10 +1757,10 @@ Explicitly set the settings path or file instead of auto determining based on fi
 
 Explicitly set the config root for resolving all configs. When used with the --resolve-all-configs flag, isort will look at all sub-folders in this config root to resolve config files and sort files based on the closest available config(if any)
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --cr
@@ -1760,10 +1770,10 @@ Explicitly set the config root for resolving all configs. When used with the --r
 
 Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --resolve-all-configs
@@ -1772,10 +1782,10 @@ Tells isort to resolve the configs for all sub-directories and sort files in ter
 
 Number of files to process in parallel. Negative value means use number of CPUs.
 
-**Type:** Int  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Int
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - -j
@@ -1785,10 +1795,10 @@ Number of files to process in parallel. Negative value means use number of CPUs.
 
 Tells isort to apply changes interactively.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --interactive
@@ -1797,22 +1807,22 @@ Tells isort to apply changes interactively.
 
 One or more Python source files that need their imports sorted.
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
-- 
+-
 
 ## Dont Follow Links
 
 Tells isort not to follow symlinks that are encountered when running recursively.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --dont-follow-links
@@ -1821,10 +1831,10 @@ Tells isort not to follow symlinks that are encountered when running recursively
 
 Provide the filename associated with a stream.
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --filename
@@ -1833,10 +1843,10 @@ Provide the filename associated with a stream.
 
 Tells isort not to treat / specially, allowing it to be run against the root dir.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --allow-root
@@ -1845,10 +1855,10 @@ Tells isort not to treat / specially, allowing it to be run against the root dir
 
 Forces --float-to-top setting off. See --float-to-top for more information.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --dont-float-to-top
@@ -1860,10 +1870,10 @@ Don't order imports by type, which is determined by case, in addition to alphabe
 **NOTE**: type here refers to the implied type from the import name capitalization.
  isort does not do type introspection for the imports. These "types" are simply: CONSTANT_VARIABLE, CamelCaseClass, variable_or_function. If your project follows PEP8 or a related coding standard and has many imports this is a good default. You can turn this on from the CLI using `--order-by-type`.
 
-**Type:** Bool  
-**Default:** `False`  
-**Config default:** `false`  
-**Python & Config File Name:** **Not Supported**  
+**Type:** Bool
+**Default:** `False`
+**Config default:** `false`
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --dt
@@ -1873,10 +1883,10 @@ Don't order imports by type, which is determined by case, in addition to alphabe
 
 Tells isort to format the given files according to an extensions formatting rules.
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - --ext-format
@@ -1885,10 +1895,10 @@ Tells isort to format the given files according to an extensions formatting rule
 
 ==SUPPRESS==
 
-**Type:** String  
-**Default:** `None`  
-**Config default:** ` `  
-**Python & Config File Name:** **Not Supported**  
+**Type:** String
+**Default:** `None`
+**Config default:** ` `
+**Python & Config File Name:** **Not Supported**
 **CLI Flags:**
 
 - -k

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -11,10 +11,10 @@ profiles](https://pycqa.github.io/isort/docs/configuration/profiles.html).
 
 Tells isort to set the known standard library based on the specified Python version. Default is to assume any Python 3 version could be the target, and use a union of all stdlib modules across versions. If auto is specified, the version of the interpreter used to run isort (currently: 39) will be used.
 
-**Type:** String
-**Default:** `py3`
-**Config default:** `3`
-**Python & Config File Name:** py_version
+**Type:** String  
+**Default:** `py3`  
+**Config default:** `3`  
+**Python & Config File Name:** py_version  
 **CLI Flags:**
 
 - --py
@@ -46,10 +46,10 @@ py_version=39
 
 Force specific imports to the top of their appropriate section.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** force_to_top
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** force_to_top  
 **CLI Flags:**
 
 - -t
@@ -59,10 +59,10 @@ Force specific imports to the top of their appropriate section.
 
 Files that isort should skip over. If you want to skip multiple files you should specify twice: `--skip file1 --skip file2`. Values can be file names, directory names or file paths. To skip all files in a nested path, use [`--skip-glob`](#skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings
-**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.pytype' '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`
-**Config default:** `['.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv']`
-**Python & Config File Name:** skip
+**Type:** List of Strings  
+**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.pytype' '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`  
+**Config default:** `['.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv']`  
+**Python & Config File Name:** skip  
 **CLI Flags:**
 
 - -s
@@ -89,10 +89,10 @@ skip = [".gitignore", ".dockerignore"]
 
 Extends --skip to add additional files that isort should skip over. If you want to skip multiple files you should specify twice: --skip file1 --skip file2. Values can be file names, directory names or file paths. To skip all files in a nested path, use [`--skip-glob`](#skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** extend_skip
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** extend_skip  
 **CLI Flags:**
 
 - --extend-skip
@@ -118,10 +118,10 @@ extend_skip = [".md", ".json"]
 
 Files that isort should skip over. To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** skip_glob
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** skip_glob  
 **CLI Flags:**
 
 - --sg
@@ -149,10 +149,10 @@ skip_glob = ["docs/*"]
 
 Additional files that isort should skip over (extending --skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** extend_skip_glob
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** extend_skip_glob  
 **CLI Flags:**
 
 - --extend-skip-glob
@@ -181,10 +181,10 @@ Treat project as a git repository and ignore files listed in .gitignore. To even
 
 NOTE: This requires git to be installed and accessible from the same shell as isort.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** skip_gitignore
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** skip_gitignore  
 **CLI Flags:**
 
 - --gitignore
@@ -194,10 +194,10 @@ NOTE: This requires git to be installed and accessible from the same shell as is
 
 The max length of an import line (used for wrapping long imports).
 
-**Type:** Int
-**Default:** `79`
-**Config default:** `79`
-**Python & Config File Name:** line_length
+**Type:** Int  
+**Default:** `79`  
+**Config default:** `79`  
+**Python & Config File Name:** line_length  
 **CLI Flags:**
 
 - -l
@@ -210,10 +210,10 @@ The max length of an import line (used for wrapping long imports).
 Specifies how long lines that are wrapped should be, if not set line_length is used.
 NOTE: wrap_length must be LOWER than or equal to line_length.
 
-**Type:** Int
-**Default:** `0`
-**Config default:** `0`
-**Python & Config File Name:** wrap_length
+**Type:** Int  
+**Default:** `0`  
+**Config default:** `0`  
+**Python & Config File Name:** wrap_length  
 **CLI Flags:**
 
 - --wl
@@ -223,10 +223,10 @@ NOTE: wrap_length must be LOWER than or equal to line_length.
 
 Forces line endings to the specified value. If not set, values will be guessed per-file.
 
-**Type:** String
-**Default:** ` `
-**Config default:** ` `
-**Python & Config File Name:** line_ending
+**Type:** String  
+**Default:** ` `  
+**Config default:** ` `  
+**Python & Config File Name:** line_ending  
 **CLI Flags:**
 
 - --le
@@ -236,10 +236,10 @@ Forces line endings to the specified value. If not set, values will be guessed p
 
 Specifies whether to sort re-exports (`__all__` collections) automatically.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** sort_reexports
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** sort_reexports  
 **CLI Flags:**
 
 - --srx
@@ -249,20 +249,20 @@ Specifies whether to sort re-exports (`__all__` collections) automatically.
 
 What sections isort should display imports for and in what order
 
-**Type:** List of Strings
-**Default:** `('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')`
-**Config default:** `['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']`
-**Python & Config File Name:** sections
+**Type:** List of Strings  
+**Default:** `('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')`  
+**Config default:** `['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']`  
+**Python & Config File Name:** sections  
 **CLI Flags:** **Not Supported**
 
 ## No Sections
 
 Put all imports into the same section bucket
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** no_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** no_sections  
 **CLI Flags:**
 
 - --ds
@@ -272,10 +272,10 @@ Put all imports into the same section bucket
 
 Force isort to recognize a module as part of Python's internal future compatibility libraries. WARNING: this overrides the behavior of __future__ handling and therefore can result in code that can't execute. If you're looking to add dependencies such as six, a better option is to create another section below --future using custom sections. See: https://github.com/PyCQA/isort#custom-sections-and-ordering and the discussion here: https://github.com/PyCQA/isort/issues/1463.
 
-**Type:** List of Strings
-**Default:** `('__future__',)`
-**Config default:** `['__future__']`
-**Python & Config File Name:** known_future_library
+**Type:** List of Strings  
+**Default:** `('__future__',)`  
+**Config default:** `['__future__']`  
+**Python & Config File Name:** known_future_library  
 **CLI Flags:**
 
 - -f
@@ -285,10 +285,10 @@ Force isort to recognize a module as part of Python's internal future compatibil
 
 Force isort to recognize a module as being part of a third party library.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** known_third_party
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** known_third_party  
 **CLI Flags:**
 
 - -o
@@ -316,10 +316,10 @@ known_third_party = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as being part of the current python project.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** known_first_party
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** known_first_party  
 **CLI Flags:**
 
 - -p
@@ -347,10 +347,10 @@ known_first_party = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as being a local folder. Generally, this is reserved for relative imports (from . import module).
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** known_local_folder
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** known_local_folder  
 **CLI Flags:**
 
 - --known-local-folder
@@ -377,10 +377,10 @@ known_local_folder = ["my_module1", "my_module2"]
 
 Force isort to recognize a module as part of Python's standard library.
 
-**Type:** List of Strings
-**Default:** `('_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo')`
-**Config default:** `['_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo']`
-**Python & Config File Name:** known_standard_library
+**Type:** List of Strings  
+**Default:** `('_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo')`  
+**Config default:** `['_ast', '_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib', 'zoneinfo']`  
+**Python & Config File Name:** known_standard_library  
 **CLI Flags:**
 
 - -b
@@ -408,10 +408,10 @@ known_standard_library = ["my_module1", "my_module2"]
 
 Extra modules to be included in the list of ones in Python's standard library.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** extra_standard_library
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** extra_standard_library  
 **CLI Flags:**
 
 - --extra-builtin
@@ -438,10 +438,10 @@ extra_standard_library = ["my_module1", "my_module2"]
 
 known_OTHER is how imports of custom sections are defined. OTHER is a placeholder for the custom section name.
 
-**Type:** Dict
-**Default:** `{}`
-**Config default:** `{}`
-**Python & Config File Name:** known_other
+**Type:** Dict  
+**Default:** `{}`  
+**Config default:** `{}`  
+**Python & Config File Name:** known_other  
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -466,10 +466,10 @@ known_airflow = ['airflow']
 
 Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-grid, 5-vert-grid-grouped, 6-deprecated-alias-for-5, 7-noqa, 8-vertical-hanging-indent-bracket, 9-vertical-prefix-from-module-import, 10-hanging-indent-with-parentheses).
 
-**Type:** Wrapmodes
-**Default:** `WrapModes.GRID`
-**Config default:** `WrapModes.GRID`
-**Python & Config File Name:** multi_line_output
+**Type:** Wrapmodes  
+**Default:** `WrapModes.GRID`  
+**Config default:** `WrapModes.GRID`  
+**Python & Config File Name:** multi_line_output  
 **CLI Flags:**
 
 - -m
@@ -495,10 +495,10 @@ multi_line_output = 3
 
 Force certain sub modules to show separately
 
-**Type:** List of Strings
-**Default:** `()`
-**Config default:** `[]`
-**Python & Config File Name:** forced_separate
+**Type:** List of Strings  
+**Default:** `()`  
+**Config default:** `[]`  
+**Python & Config File Name:** forced_separate  
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -523,10 +523,10 @@ forced_separate = ["glob_exp1", "glob_exp2"]
 
 String to place for indents defaults to "    " (4 spaces).
 
-**Type:** String
-**Default:** `    `
-**Config default:** `    `
-**Python & Config File Name:** indent
+**Type:** String  
+**Default:** `    `  
+**Config default:** `    `  
+**Python & Config File Name:** indent  
 **CLI Flags:**
 
 - -i
@@ -536,20 +536,20 @@ String to place for indents defaults to "    " (4 spaces).
 
 Allows customizing how isort prefixes comments that it adds or modifies on import linesGenerally `  #` (two spaces before a pound symbol) is use, though one space is also common.
 
-**Type:** String
-**Default:** `  #`
-**Config default:** `  #`
-**Python & Config File Name:** comment_prefix
+**Type:** String  
+**Default:** `  #`  
+**Config default:** `  #`  
+**Python & Config File Name:** comment_prefix  
 **CLI Flags:** **Not Supported**
 
 ## Length Sort
 
 Sort imports by their string length.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** length_sort
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** length_sort  
 **CLI Flags:**
 
 - --ls
@@ -559,10 +559,10 @@ Sort imports by their string length.
 
 Sort straight imports by their string length. Similar to `length_sort` but applies only to straight imports and doesn't affect from imports.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** length_sort_straight
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** length_sort_straight  
 **CLI Flags:**
 
 - --lss
@@ -572,10 +572,10 @@ Sort straight imports by their string length. Similar to `length_sort` but appli
 
 Sort the given sections by length
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** length_sort_sections
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** length_sort_sections  
 **CLI Flags:** **Not Supported**
 
 **Examples:**
@@ -600,10 +600,10 @@ length_sort_sections = ["future", "stdlib"]
 
 Adds the specified import line to all files, automatically determining correct placement.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** add_imports
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** add_imports  
 **CLI Flags:**
 
 - -a
@@ -631,10 +631,10 @@ add_imports = ["import os", "import json"]
 
 Removes the specified import from all files.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** remove_imports
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** remove_imports  
 **CLI Flags:**
 
 - --rm
@@ -662,10 +662,10 @@ remove_imports = ["os", "json"]
 
 Only adds the imports specified in --add-import if the file contains existing imports.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** append_only
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** append_only  
 **CLI Flags:**
 
 - --append
@@ -675,10 +675,10 @@ Only adds the imports specified in --add-import if the file contains existing im
 
 Reverse order of relative imports.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** reverse_relative
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** reverse_relative  
 **CLI Flags:**
 
 - --rr
@@ -688,10 +688,10 @@ Reverse order of relative imports.
 
 Forces all from imports to appear on their own line
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** force_single_line
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** force_single_line  
 **CLI Flags:**
 
 - --sl
@@ -701,10 +701,10 @@ Forces all from imports to appear on their own line
 
 One or more modules to exclude from the single line rule.
 
-**Type:** List of Strings
-**Default:** `()`
-**Config default:** `[]`
-**Python & Config File Name:** single_line_exclusions
+**Type:** List of Strings  
+**Default:** `()`  
+**Config default:** `[]`  
+**Python & Config File Name:** single_line_exclusions  
 **CLI Flags:**
 
 - --nsl
@@ -732,10 +732,10 @@ single_line_exclusions = ["os", "json"]
 
 Sets the default section for import options: ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')
 
-**Type:** String
-**Default:** `THIRDPARTY`
-**Config default:** `THIRDPARTY`
-**Python & Config File Name:** default_section
+**Type:** String  
+**Default:** `THIRDPARTY`  
+**Config default:** `THIRDPARTY`  
+**Python & Config File Name:** default_section  
 **CLI Flags:**
 
 - --sd
@@ -745,30 +745,30 @@ Sets the default section for import options: ('FUTURE', 'STDLIB', 'THIRDPARTY', 
 
 A mapping of import sections to import heading comments that should show above them.
 
-**Type:** Dict
-**Default:** `{}`
-**Config default:** `{}`
-**Python & Config File Name:** import_headings
+**Type:** Dict  
+**Default:** `{}`  
+**Config default:** `{}`  
+**Python & Config File Name:** import_headings  
 **CLI Flags:** **Not Supported**
 
 ## Import Footers
 
 A mapping of import sections to import footer comments that should show below them.
 
-**Type:** Dict
-**Default:** `{}`
-**Config default:** `{}`
-**Python & Config File Name:** import_footers
+**Type:** Dict  
+**Default:** `{}`  
+**Config default:** `{}`  
+**Python & Config File Name:** import_footers  
 **CLI Flags:** **Not Supported**
 
 ## Balanced Wrapping
 
 Balances wrapping to produce the most consistent line length possible
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** balanced_wrapping
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** balanced_wrapping  
 **CLI Flags:**
 
 - -e
@@ -778,10 +778,10 @@ Balances wrapping to produce the most consistent line length possible
 
 Use parentheses for line continuation on length limit instead of backslashes. **NOTE**: This is separate from wrap modes, and only affects how individual lines that  are too long get continued, not sections of multiple imports.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** use_parentheses
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** use_parentheses  
 **CLI Flags:**
 
 - --up
@@ -794,10 +794,10 @@ Order imports by type, which is determined by case, in addition to alphabeticall
 **NOTE**: type here refers to the implied type from the import name capitalization.
  isort does not do type introspection for the imports. These "types" are simply: CONSTANT_VARIABLE, CamelCaseClass, variable_or_function. If your project follows PEP8 or a related coding standard and has many imports this is a good default, otherwise you likely will want to turn it off. From the CLI the `--dont-order-by-type` option will turn this off.
 
-**Type:** Bool
-**Default:** `True`
-**Config default:** `true`
-**Python & Config File Name:** order_by_type
+**Type:** Bool  
+**Default:** `True`  
+**Config default:** `true`  
+**Python & Config File Name:** order_by_type  
 **CLI Flags:**
 
 - --ot
@@ -807,10 +807,10 @@ Order imports by type, which is determined by case, in addition to alphabeticall
 
 Ensures the output doesn't save if the resulting file contains syntax errors.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** atomic
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** atomic  
 **CLI Flags:**
 
 - --ac
@@ -820,10 +820,10 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 
 The number of blank lines to place before imports. -1 for automatic determination
 
-**Type:** Int
-**Default:** `-1`
-**Config default:** `-1`
-**Python & Config File Name:** lines_before_imports
+**Type:** Int  
+**Default:** `-1`  
+**Config default:** `-1`  
+**Python & Config File Name:** lines_before_imports  
 **CLI Flags:**
 
 - --lbi
@@ -833,10 +833,10 @@ The number of blank lines to place before imports. -1 for automatic determinatio
 
 The number of blank lines to place after imports. -1 for automatic determination
 
-**Type:** Int
-**Default:** `-1`
-**Config default:** `-1`
-**Python & Config File Name:** lines_after_imports
+**Type:** Int  
+**Default:** `-1`  
+**Config default:** `-1`  
+**Python & Config File Name:** lines_after_imports  
 **CLI Flags:**
 
 - --lai
@@ -846,20 +846,20 @@ The number of blank lines to place after imports. -1 for automatic determination
 
 The number of lines to place between sections
 
-**Type:** Int
-**Default:** `1`
-**Config default:** `1`
-**Python & Config File Name:** lines_between_sections
+**Type:** Int  
+**Default:** `1`  
+**Config default:** `1`  
+**Python & Config File Name:** lines_between_sections  
 **CLI Flags:** **Not Supported**
 
 ## Lines Between Types
 
 The number of lines to place between direct and from imports
 
-**Type:** Int
-**Default:** `0`
-**Config default:** `0`
-**Python & Config File Name:** lines_between_types
+**Type:** Int  
+**Default:** `0`  
+**Config default:** `0`  
+**Python & Config File Name:** lines_between_types  
 **CLI Flags:**
 
 - --lbt
@@ -869,10 +869,10 @@ The number of lines to place between direct and from imports
 
 Combines as imports on the same line.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** combine_as_imports
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** combine_as_imports  
 **CLI Flags:**
 
 - --ca
@@ -882,10 +882,10 @@ Combines as imports on the same line.
 
 Ensures that if a star import is present, nothing else is imported from that namespace.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** combine_star
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** combine_star  
 **CLI Flags:**
 
 - --cs
@@ -895,10 +895,10 @@ Ensures that if a star import is present, nothing else is imported from that nam
 
 Includes a trailing comma on multi line imports that include parentheses.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** include_trailing_comma
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** include_trailing_comma  
 **CLI Flags:**
 
 - --tc
@@ -907,10 +907,10 @@ Includes a trailing comma on multi line imports that include parentheses.
 
 Split imports list followed by a trailing comma into VERTICAL_HANGING_INDENT mode. This follows Black style magic comma.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** split_on_trailing_comma
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** split_on_trailing_comma  
 **CLI Flags:**
 
 - --split-on-trailing-comma
@@ -919,10 +919,10 @@ Split imports list followed by a trailing comma into VERTICAL_HANGING_INDENT mod
 
 Switches the typical ordering preference, showing from imports first then straight ones.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** from_first
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** from_first  
 **CLI Flags:**
 
 - --ff
@@ -932,10 +932,10 @@ Switches the typical ordering preference, showing from imports first then straig
 
 Shows verbose output, such as when files are skipped or when a check is successful.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** verbose
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** verbose  
 **CLI Flags:**
 
 - -v
@@ -945,10 +945,10 @@ Shows verbose output, such as when files are skipped or when a check is successf
 
 Shows extra quiet output, only errors are outputted.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** quiet
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** quiet  
 **CLI Flags:**
 
 - -q
@@ -958,10 +958,10 @@ Shows extra quiet output, only errors are outputted.
 
 Forces import adds even if the original file is empty.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** force_adds
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** force_adds  
 **CLI Flags:**
 
 - --af
@@ -971,10 +971,10 @@ Forces import adds even if the original file is empty.
 
 Force all imports to be sorted alphabetically within a section
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** force_alphabetical_sort_within_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** force_alphabetical_sort_within_sections  
 **CLI Flags:**
 
 - --fass
@@ -984,10 +984,10 @@ Force all imports to be sorted alphabetically within a section
 
 Force all imports to be sorted as a single section
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** force_alphabetical_sort
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** force_alphabetical_sort  
 **CLI Flags:**
 
 - --fas
@@ -997,10 +997,10 @@ Force all imports to be sorted as a single section
 
 Force number of from imports (defaults to 2 when passed as CLI flag without value) to be grid wrapped regardless of line length. If 0 is passed in (the global default) only line length is considered.
 
-**Type:** Int
-**Default:** `0`
-**Config default:** `0`
-**Python & Config File Name:** force_grid_wrap
+**Type:** Int  
+**Default:** `0`  
+**Config default:** `0`  
+**Python & Config File Name:** force_grid_wrap  
 **CLI Flags:**
 
 - --fgw
@@ -1010,10 +1010,10 @@ Force number of from imports (defaults to 2 when passed as CLI flag without valu
 
 Don't sort straight-style imports (like import sys) before from-style imports (like from itertools import groupby). Instead, sort the imports by module, independent of import style.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** force_sort_within_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** force_sort_within_sections  
 **CLI Flags:**
 
 - --fss
@@ -1023,40 +1023,41 @@ Don't sort straight-style imports (like import sys) before from-style imports (l
 
 Lexicographical order is strictly alphabetical order. For example by default isort will sort `1, 10, 2` into `1, 2, 10` - but with lexicographical sorting enabled it will remain `1, 10, 2`.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** lexicographical
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** lexicographical  
 **CLI Flags:** **Not Supported**
 
 ## Group By Package
 
 If `True` isort will automatically create section groups by the top-level package they come from.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** group_by_package
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** group_by_package  
 **CLI Flags:** **Not Supported**
 
-## Separate Top-Level Packages
+## Separate Packages
 
-Separate top-level packages with newlines.
+Separate packages within the listed sections with newlines.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** separate_top_level_packages
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** separate_packages  
 **CLI Flags:** **Not Supported**
+
 
 ## Ignore Whitespace
 
 Tells isort to ignore whitespace differences when --check-only is being used.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** ignore_whitespace
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** ignore_whitespace  
 **CLI Flags:**
 
 - --ws
@@ -1066,10 +1067,10 @@ Tells isort to ignore whitespace differences when --check-only is being used.
 
 Sections which should not be split with previous by empty lines
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** no_lines_before
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** no_lines_before  
 **CLI Flags:**
 
 - --nlb
@@ -1097,10 +1098,10 @@ no_lines_before = ["future", "stdlib"]
 
 Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c ,b`).
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** no_inline_sort
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** no_inline_sort  
 **CLI Flags:**
 
 - --nis
@@ -1110,20 +1111,20 @@ Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c 
 
 If enabled, isort will strip comments that exist within import lines.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** ignore_comments
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** ignore_comments  
 **CLI Flags:** **Not Supported**
 
 ## Case Sensitive
 
 Tells isort to include casing when sorting module names
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** case_sensitive
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** case_sensitive  
 **CLI Flags:**
 
 - --case-sensitive
@@ -1132,10 +1133,10 @@ Tells isort to include casing when sorting module names
 
 Virtual environment to use for determining whether a package is third-party
 
-**Type:** String
-**Default:** ` `
-**Config default:** ` `
-**Python & Config File Name:** virtual_env
+**Type:** String  
+**Default:** ` `  
+**Config default:** ` `  
+**Python & Config File Name:** virtual_env  
 **CLI Flags:**
 
 - --virtual-env
@@ -1144,10 +1145,10 @@ Virtual environment to use for determining whether a package is third-party
 
 Conda environment to use for determining whether a package is third-party
 
-**Type:** String
-**Default:** ` `
-**Config default:** ` `
-**Python & Config File Name:** conda_env
+**Type:** String  
+**Default:** ` `  
+**Config default:** ` `  
+**Python & Config File Name:** conda_env  
 **CLI Flags:**
 
 - --conda-env
@@ -1156,10 +1157,10 @@ Conda environment to use for determining whether a package is third-party
 
 Inserts a blank line before a comment following an import.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** ensure_newline_before_comments
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** ensure_newline_before_comments  
 **CLI Flags:**
 
 - -n
@@ -1172,10 +1173,10 @@ pycharm, google, open\_stack, plone, attrs, hug, wemake, appnexus. As well as
 any [shared
 profiles](https://pycqa.github.io/isort/docs/howto/shared_profiles.html).
 
-**Type:** String
-**Default:** ` `
-**Config default:** ` `
-**Python & Config File Name:** profile
+**Type:** String  
+**Default:** ` `  
+**Config default:** ` `  
+**Python & Config File Name:** profile  
 **CLI Flags:**
 
 - --profile
@@ -1184,10 +1185,10 @@ profiles](https://pycqa.github.io/isort/docs/howto/shared_profiles.html).
 
 Tells isort to honor noqa comments to enforce skipping those comments.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** honor_noqa
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** honor_noqa  
 **CLI Flags:**
 
 - --honor-noqa
@@ -1196,10 +1197,10 @@ Tells isort to honor noqa comments to enforce skipping those comments.
 
 Add an explicitly defined source path (modules within src paths have their imports automatically categorized as first_party). Glob expansion (`*` and `**`) is supported for this option.
 
-**Type:** List of Strings
-**Default:** `()`
-**Config default:** `[]`
-**Python & Config File Name:** src_paths
+**Type:** List of Strings  
+**Default:** `()`  
+**Config default:** `[]`  
+**Python & Config File Name:** src_paths  
 **CLI Flags:**
 
 - --src
@@ -1227,10 +1228,10 @@ src_paths = ["src", "tests"]
 
 Use the old deprecated finder logic that relies on environment introspection magic.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** old_finders
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** old_finders  
 **CLI Flags:**
 
 - --old-finders
@@ -1240,10 +1241,10 @@ Use the old deprecated finder logic that relies on environment introspection mag
 
 Tells isort to remove redundant aliases from imports, such as `import os as os`. This defaults to `False` simply because some projects use these seemingly useless  aliases to signify intent and change behaviour.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** remove_redundant_aliases
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** remove_redundant_aliases  
 **CLI Flags:**
 
 - --remove-redundant-aliases
@@ -1255,10 +1256,10 @@ This can be an excellent shortcut for collecting imports every once in a while w
 
 *NOTE*: It currently doesn't work with cimports and introduces some extra over-head and a performance penalty.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** float_to_top
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** float_to_top  
 **CLI Flags:**
 
 - --float-to-top
@@ -1267,10 +1268,10 @@ This can be an excellent shortcut for collecting imports every once in a while w
 
 Tells isort to filter files even when they are explicitly passed in as part of the CLI command.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** filter_files
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** filter_files  
 **CLI Flags:**
 
 - --filter-files
@@ -1279,10 +1280,10 @@ Tells isort to filter files even when they are explicitly passed in as part of t
 
 Specifies the name of a formatting plugin to use when producing output.
 
-**Type:** String
-**Default:** ` `
-**Config default:** ` `
-**Python & Config File Name:** formatter
+**Type:** String  
+**Default:** ` `  
+**Config default:** ` `  
+**Python & Config File Name:** formatter  
 **CLI Flags:**
 
 - --formatter
@@ -1291,20 +1292,20 @@ Specifies the name of a formatting plugin to use when producing output.
 
 The fully qualified Python path of a function to apply to format code sorted by isort.
 
-**Type:** Nonetype
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** formatting_function
+**Type:** Nonetype  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** formatting_function  
 **CLI Flags:** **Not Supported**
 
 ## Color Output
 
 Tells isort to use color in terminal output.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** color_output
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** color_output  
 **CLI Flags:**
 
 - --color
@@ -1313,10 +1314,10 @@ Tells isort to use color in terminal output.
 
 Tells isort to treat the specified single line comment(s) as if they are code.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** treat_comments_as_code
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** treat_comments_as_code  
 **CLI Flags:**
 
 - --treat-comment-as-code
@@ -1343,10 +1344,10 @@ treat_comments_as_code = ["# my comment 1", "# my other comment"]
 
 Tells isort to treat all single line comments as if they are code.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** treat_all_comments_as_code
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** treat_all_comments_as_code  
 **CLI Flags:**
 
 - --treat-all-comment-as-code
@@ -1355,10 +1356,10 @@ Tells isort to treat all single line comments as if they are code.
 
 Specifies what extensions isort can be run against.
 
-**Type:** List of Strings
-**Default:** `('pxd', 'py', 'pyi', 'pyx')`
-**Config default:** `['pxd', 'py', 'pyi', 'pyx']`
-**Python & Config File Name:** supported_extensions
+**Type:** List of Strings  
+**Default:** `('pxd', 'py', 'pyi', 'pyx')`  
+**Config default:** `['pxd', 'py', 'pyi', 'pyx']`  
+**Python & Config File Name:** supported_extensions  
 **CLI Flags:**
 
 - --ext
@@ -1387,10 +1388,10 @@ supported_extensions = ["pyw", "ext"]
 
 Specifies what extensions isort can never be run against.
 
-**Type:** List of Strings
-**Default:** `('pex',)`
-**Config default:** `['pex']`
-**Python & Config File Name:** blocked_extensions
+**Type:** List of Strings  
+**Default:** `('pex',)`  
+**Config default:** `['pex']`  
+**Python & Config File Name:** blocked_extensions  
 **CLI Flags:**
 
 - --blocked-extension
@@ -1417,40 +1418,40 @@ blocked_extensions = ["pyw", "pyc"]
 
 An override list of tokens to always recognize as a CONSTANT for order_by_type regardless of casing.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** constants
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** constants  
 **CLI Flags:** **Not Supported**
 
 ## Classes
 
 An override list of tokens to always recognize as a Class for order_by_type regardless of casing.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** classes
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** classes  
 **CLI Flags:** **Not Supported**
 
 ## Variables
 
 An override list of tokens to always recognize as a var for order_by_type regardless of casing.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** variables
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** variables  
 **CLI Flags:** **Not Supported**
 
 ## Dedup Headings
 
 Tells isort to only show an identical custom import heading comment once, even if there are multiple sections with the comment set.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** dedup_headings
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** dedup_headings  
 **CLI Flags:**
 
 - --dedup-headings
@@ -1459,10 +1460,10 @@ Tells isort to only show an identical custom import heading comment once, even i
 
 Causes imports to be sorted based on their sections like STDLIB, THIRDPARTY, etc. Within sections, the imports are ordered by their import style and the imports with the same style maintain their relative positions.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** only_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** only_sections  
 **CLI Flags:**
 
 - --only-sections
@@ -1472,10 +1473,10 @@ Causes imports to be sorted based on their sections like STDLIB, THIRDPARTY, etc
 
 Suppresses verbose output for non-modified files.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** only_modified
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** only_modified  
 **CLI Flags:**
 
 - --only-modified
@@ -1485,10 +1486,10 @@ Suppresses verbose output for non-modified files.
 
 Combines all the bare straight imports of the same section in a single line. Won't work with sections which have 'as' imports
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** combine_straight_imports
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** combine_straight_imports  
 **CLI Flags:**
 
 - --combine-straight-imports
@@ -1498,50 +1499,50 @@ Combines all the bare straight imports of the same section in a single line. Won
 
 Automatically determine local namespace packages, generally by lack of any src files before a src containing directory.
 
-**Type:** Bool
-**Default:** `True`
-**Config default:** `true`
-**Python & Config File Name:** auto_identify_namespace_packages
+**Type:** Bool  
+**Default:** `True`  
+**Config default:** `true`  
+**Python & Config File Name:** auto_identify_namespace_packages  
 **CLI Flags:** **Not Supported**
 
 ## Namespace Packages
 
 Manually specify one or more namespace packages.
 
-**Type:** List of Strings
-**Default:** `frozenset()`
-**Config default:** `[]`
-**Python & Config File Name:** namespace_packages
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** namespace_packages  
 **CLI Flags:** **Not Supported**
 
 ## Follow Links
 
 If `True` isort will follow symbolic links when doing recursive sorting.
 
-**Type:** Bool
-**Default:** `True`
-**Config default:** `true`
-**Python & Config File Name:** follow_links
+**Type:** Bool  
+**Default:** `True`  
+**Config default:** `true`  
+**Python & Config File Name:** follow_links  
 **CLI Flags:** **Not Supported**
 
 ## Indented Import Headings
 
 If `True` isort will apply import headings to indented imports the same way it does unindented ones.
 
-**Type:** Bool
-**Default:** `True`
-**Config default:** `true`
-**Python & Config File Name:** indented_import_headings
+**Type:** Bool  
+**Default:** `True`  
+**Config default:** `true`  
+**Python & Config File Name:** indented_import_headings  
 **CLI Flags:** **Not Supported**
 
 ## Honor Case In Force Sorted Sections
 
 Honor `--case-sensitive` when `--force-sort-within-sections` is being used. Without this option set, `--order-by-type` decides module name ordering too.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** honor_case_in_force_sorted_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** honor_case_in_force_sorted_sections  
 **CLI Flags:**
 
 - --hcss
@@ -1551,10 +1552,10 @@ Honor `--case-sensitive` when `--force-sort-within-sections` is being used. With
 
 When using `--force-sort-within-sections`, sort relative imports the same way as they are sorted when not using that setting.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** sort_relative_in_force_sorted_sections
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** sort_relative_in_force_sorted_sections  
 **CLI Flags:**
 
 - --srss
@@ -1564,10 +1565,10 @@ When using `--force-sort-within-sections`, sort relative imports the same way as
 
 Tells isort to overwrite in place using the same file handle. Comes at a performance and memory usage penalty over its standard approach but ensures all file flags and modes stay unchanged.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** overwrite_in_place
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** overwrite_in_place  
 **CLI Flags:**
 
 - --overwrite-in-place
@@ -1576,10 +1577,10 @@ Tells isort to overwrite in place using the same file handle. Comes at a perform
 
 Reverses the ordering of imports.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** reverse_sort
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** reverse_sort  
 **CLI Flags:**
 
 - --reverse-sort
@@ -1588,10 +1589,10 @@ Reverses the ordering of imports.
 
 Forces star imports above others to avoid overriding directly imported variables.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** star_first
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** star_first  
 **CLI Flags:**
 
 - --star-first
@@ -1600,20 +1601,20 @@ Forces star imports above others to avoid overriding directly imported variables
 
 If `True` isort will honor ignores within locally defined .git_ignore files.
 
-**Type:** Dict
-**Default:** `{}`
-**Config default:** `{}`
-**Python & Config File Name:** git_ignore
+**Type:** Dict  
+**Default:** `{}`  
+**Config default:** `{}`  
+**Python & Config File Name:** git_ignore  
 **CLI Flags:** **Not Supported**
 
 ## Format Error
 
 Override the format used to print errors.
 
-**Type:** String
-**Default:** `{error}: {message}`
-**Config default:** `{error}: {message}`
-**Python & Config File Name:** format_error
+**Type:** String  
+**Default:** `{error}: {message}`  
+**Config default:** `{error}: {message}`  
+**Python & Config File Name:** format_error  
 **CLI Flags:**
 
 - --format-error
@@ -1622,10 +1623,10 @@ Override the format used to print errors.
 
 Override the format used to print success.
 
-**Type:** String
-**Default:** `{success}: {message}`
-**Config default:** `{success}: {message}`
-**Python & Config File Name:** format_success
+**Type:** String  
+**Default:** `{success}: {message}`  
+**Config default:** `{success}: {message}`  
+**Python & Config File Name:** format_success  
 **CLI Flags:**
 
 - --format-success
@@ -1634,10 +1635,10 @@ Override the format used to print success.
 
 Specify sorting function. Can be built in (natural[default] = force numbers to be sequential, native = Python's built-in sorted function) or an installable plugin.
 
-**Type:** String
-**Default:** `natural`
-**Config default:** `natural`
-**Python & Config File Name:** sort_order
+**Type:** String  
+**Default:** `natural`  
+**Config default:** `natural`  
+**Python & Config File Name:** sort_order  
 **CLI Flags:**
 
 - --sort-order
@@ -1646,10 +1647,10 @@ Specify sorting function. Can be built in (natural[default] = force numbers to b
 
 Displays the currently installed version of isort.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - -V
@@ -1665,10 +1666,10 @@ Displays the currently installed version of isort.
 
 Returns just the current version number without the logo
 
-**Type:** String
-**Default:** `==SUPPRESS==`
-**Config default:** `==SUPPRESS==`
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `==SUPPRESS==`  
+**Config default:** `==SUPPRESS==`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --vn
@@ -1678,10 +1679,10 @@ Returns just the current version number without the logo
 
 Force resulting output to stdout, instead of in-place.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - -d
@@ -1691,10 +1692,10 @@ Force resulting output to stdout, instead of in-place.
 
 See isort's determined config, as well as sources of config options.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --show-config
@@ -1703,10 +1704,10 @@ See isort's determined config, as well as sources of config options.
 
 See the files isort will be run against with the current config options.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --show-files
@@ -1715,10 +1716,10 @@ See the files isort will be run against with the current config options.
 
 Prints a diff of all the changes isort would make to a file, instead of changing it in place
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --df
@@ -1728,10 +1729,10 @@ Prints a diff of all the changes isort would make to a file, instead of changing
 
 Checks the file for unsorted / unformatted imports and prints them to the command line without modifying the file. Returns 0 when nothing would change and returns 1 when the file would be reformatted.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - -c
@@ -1742,10 +1743,10 @@ Checks the file for unsorted / unformatted imports and prints them to the comman
 
 Explicitly set the settings path or file instead of auto determining based on file location.
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --sp
@@ -1757,10 +1758,10 @@ Explicitly set the settings path or file instead of auto determining based on fi
 
 Explicitly set the config root for resolving all configs. When used with the --resolve-all-configs flag, isort will look at all sub-folders in this config root to resolve config files and sort files based on the closest available config(if any)
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --cr
@@ -1770,10 +1771,10 @@ Explicitly set the config root for resolving all configs. When used with the --r
 
 Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --resolve-all-configs
@@ -1782,10 +1783,10 @@ Tells isort to resolve the configs for all sub-directories and sort files in ter
 
 Number of files to process in parallel. Negative value means use number of CPUs.
 
-**Type:** Int
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** Int  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - -j
@@ -1795,10 +1796,10 @@ Number of files to process in parallel. Negative value means use number of CPUs.
 
 Tells isort to apply changes interactively.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --interactive
@@ -1807,22 +1808,22 @@ Tells isort to apply changes interactively.
 
 One or more Python source files that need their imports sorted.
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
--
+- 
 
 ## Dont Follow Links
 
 Tells isort not to follow symlinks that are encountered when running recursively.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --dont-follow-links
@@ -1831,10 +1832,10 @@ Tells isort not to follow symlinks that are encountered when running recursively
 
 Provide the filename associated with a stream.
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --filename
@@ -1843,10 +1844,10 @@ Provide the filename associated with a stream.
 
 Tells isort not to treat / specially, allowing it to be run against the root dir.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --allow-root
@@ -1855,10 +1856,10 @@ Tells isort not to treat / specially, allowing it to be run against the root dir
 
 Forces --float-to-top setting off. See --float-to-top for more information.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --dont-float-to-top
@@ -1870,10 +1871,10 @@ Don't order imports by type, which is determined by case, in addition to alphabe
 **NOTE**: type here refers to the implied type from the import name capitalization.
  isort does not do type introspection for the imports. These "types" are simply: CONSTANT_VARIABLE, CamelCaseClass, variable_or_function. If your project follows PEP8 or a related coding standard and has many imports this is a good default. You can turn this on from the CLI using `--order-by-type`.
 
-**Type:** Bool
-**Default:** `False`
-**Config default:** `false`
-**Python & Config File Name:** **Not Supported**
+**Type:** Bool  
+**Default:** `False`  
+**Config default:** `false`  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --dt
@@ -1883,10 +1884,10 @@ Don't order imports by type, which is determined by case, in addition to alphabe
 
 Tells isort to format the given files according to an extensions formatting rules.
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - --ext-format
@@ -1895,10 +1896,10 @@ Tells isort to format the given files according to an extensions formatting rule
 
 ==SUPPRESS==
 
-**Type:** String
-**Default:** `None`
-**Config default:** ` `
-**Python & Config File Name:** **Not Supported**
+**Type:** String  
+**Default:** `None`  
+**Config default:** ` `  
+**Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
 - -k

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1049,7 +1049,6 @@ Separate packages within the listed sections with newlines.
 **Python & Config File Name:** separate_packages  
 **CLI Flags:** **Not Supported**
 
-
 ## Ignore Whitespace
 
 Tells isort to ignore whitespace differences when --check-only is being used.

--- a/isort/output.py
+++ b/isort/output.py
@@ -173,6 +173,22 @@ def sorted_imports(
                     processed_section_output.append(section_line)
                 section_output = processed_section_output
 
+            if section in config.separate_third_level_packages:
+                previous_package_name: Optional[str] = None
+                processed_section_output: list[str] = []
+
+                for section_line in section_output:
+                    package_name: str = ".".join(section_line.split(" ")[1].split(".")[0:3])
+
+                    if previous_package_name is not None:
+                        if package_name != previous_package_name:
+                            processed_section_output.append("")
+                    previous_package_name = package_name
+                    processed_section_output.append(section_line)
+
+                section_output = processed_section_output
+
+
             if pending_lines_before or not no_lines_before:
                 output += [""] * config.lines_between_sections
 

--- a/isort/output.py
+++ b/isort/output.py
@@ -152,8 +152,13 @@ def sorted_imports(
 
             if section in config.separate_packages:
                 group_keys: list[str] = []
+                comments_above: list[str] = []
                 processed_section_output: list[str] = []
                 for section_line in section_output:
+                    if section_line.startswith("#"):
+                        comments_above.append(section_line)
+                        continue
+
                     package_name: str = section_line.split(" ")[1]
                     _, reason = module_with_reason(package_name, config)
 
@@ -168,6 +173,10 @@ def sorted_imports(
                             processed_section_output.append("")
 
                         group_keys.append(key)
+
+                    if comments_above:
+                        processed_section_output.extend(comments_above)
+                        comments_above = []
 
                     processed_section_output.append(section_line)
 

--- a/isort/output.py
+++ b/isort/output.py
@@ -149,18 +149,29 @@ def sorted_imports(
                     section_output.append("")  # Empty line for black compatibility
                     section_output.append(section_comment_end)
 
-            if section != "STDLIB":
-                if config.separate_top_level_packages:
-                    previous_package_name: Optional[str] = None
-                    processed_section_output: list[str] = []
-                    for section_line in section_output:
-                        package_name: str = section_line.split(" ")[1].split(".")[0]
-                        if previous_package_name is not None:
-                            if package_name != previous_package_name:
-                                processed_section_output.append("")
-                        previous_package_name = package_name
-                        processed_section_output.append(section_line)
-                    section_output = processed_section_output
+            if section in config.separate_first_level_packages:
+                previous_package_name: Optional[str] = None
+                processed_section_output: list[str] = []
+                for section_line in section_output:
+                    package_name: str = section_line.split(" ")[1].split(".")[0]
+                    if previous_package_name is not None:
+                        if package_name != previous_package_name:
+                            processed_section_output.append("")
+                    previous_package_name = package_name
+                    processed_section_output.append(section_line)
+                section_output = processed_section_output
+
+            if section in config.separate_second_level_packages:
+                previous_package_name: Optional[str] = None
+                processed_section_output: list[str] = []
+                for section_line in section_output:
+                    package_name: str = ".".join(section_line.split(" ")[1].split(".")[0:2])
+                    if previous_package_name is not None:
+                        if package_name != previous_package_name:
+                            processed_section_output.append("")
+                    previous_package_name = package_name
+                    processed_section_output.append(section_line)
+                section_output = processed_section_output
 
             if pending_lines_before or not no_lines_before:
                 output += [""] * config.lines_between_sections

--- a/isort/output.py
+++ b/isort/output.py
@@ -151,7 +151,7 @@ def sorted_imports(
                     section_output.append(section_comment_end)
 
             if section in config.separate_packages:
-                group_keys: list[str] = []
+                group_keys: set[str] = set()
                 comments_above: list[str] = []
                 processed_section_output: list[str] = []
                 for section_line in section_output:
@@ -172,7 +172,7 @@ def sorted_imports(
                         if group_keys:
                             processed_section_output.append("")
 
-                        group_keys.append(key)
+                        group_keys.add(key)
 
                     if comments_above:
                         processed_section_output.extend(comments_above)

--- a/isort/output.py
+++ b/isort/output.py
@@ -149,6 +149,18 @@ def sorted_imports(
                     section_output.append("")  # Empty line for black compatibility
                     section_output.append(section_comment_end)
 
+            if config.separate_top_level_packages:
+                previous_package_name: Optional[str] = None
+                processed_section_output: list[str] = []
+                for section_line in section_output:
+                    package_name: str = section_line.split(" ")[1].split(".")[0]
+                    if previous_package_name is not None:
+                        if package_name != previous_package_name:
+                            processed_section_output.append("")
+                    previous_package_name = package_name
+                    processed_section_output.append(section_line)
+                section_output = processed_section_output
+
             if pending_lines_before or not no_lines_before:
                 output += [""] * config.lines_between_sections
 

--- a/isort/output.py
+++ b/isort/output.py
@@ -149,17 +149,18 @@ def sorted_imports(
                     section_output.append("")  # Empty line for black compatibility
                     section_output.append(section_comment_end)
 
-            if config.separate_top_level_packages:
-                previous_package_name: Optional[str] = None
-                processed_section_output: list[str] = []
-                for section_line in section_output:
-                    package_name: str = section_line.split(" ")[1].split(".")[0]
-                    if previous_package_name is not None:
-                        if package_name != previous_package_name:
-                            processed_section_output.append("")
-                    previous_package_name = package_name
-                    processed_section_output.append(section_line)
-                section_output = processed_section_output
+            if section != "STDLIB":
+                if config.separate_top_level_packages:
+                    previous_package_name: Optional[str] = None
+                    processed_section_output: list[str] = []
+                    for section_line in section_output:
+                        package_name: str = section_line.split(" ")[1].split(".")[0]
+                        if previous_package_name is not None:
+                            if package_name != previous_package_name:
+                                processed_section_output.append("")
+                        previous_package_name = package_name
+                        processed_section_output.append(section_line)
+                    section_output = processed_section_output
 
             if pending_lines_before or not no_lines_before:
                 output += [""] * config.lines_between_sections

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -200,9 +200,7 @@ class _Config:
     force_sort_within_sections: bool = False
     lexicographical: bool = False
     group_by_package: bool = False
-    separate_first_level_packages: FrozenSet[str] = frozenset()
-    separate_second_level_packages: FrozenSet[str] = frozenset()
-    separate_third_level_packages: FrozenSet[str] = frozenset()
+    separate_packages: FrozenSet[str] = frozenset()
     ignore_whitespace: bool = False
     no_lines_before: FrozenSet[str] = frozenset()
     no_inline_sort: bool = False

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -200,7 +200,8 @@ class _Config:
     force_sort_within_sections: bool = False
     lexicographical: bool = False
     group_by_package: bool = False
-    separate_top_level_packages: bool = False
+    separate_first_level_packages: FrozenSet[str] = frozenset()
+    separate_second_level_packages: FrozenSet[str] = frozenset()
     ignore_whitespace: bool = False
     no_lines_before: FrozenSet[str] = frozenset()
     no_inline_sort: bool = False

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -202,6 +202,7 @@ class _Config:
     group_by_package: bool = False
     separate_first_level_packages: FrozenSet[str] = frozenset()
     separate_second_level_packages: FrozenSet[str] = frozenset()
+    separate_third_level_packages: FrozenSet[str] = frozenset()
     ignore_whitespace: bool = False
     no_lines_before: FrozenSet[str] = frozenset()
     no_inline_sort: bool = False

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -200,6 +200,7 @@ class _Config:
     force_sort_within_sections: bool = False
     lexicographical: bool = False
     group_by_package: bool = False
+    separate_top_level_packages: bool = False
     ignore_whitespace: bool = False
     no_lines_before: FrozenSet[str] = frozenset()
     no_inline_sort: bool = False


### PR DESCRIPTION
Resolves https://github.com/PyCQA/isort/issues/2104, allowing packages within a section to be separated by a new line. Packages in deeper directories can be separated in the same manner by stating their "parents" in a `known_OTHER` section.