### PR TITLE
chore: remove py3.8 types

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -691,10 +691,10 @@ def _with_star_comments(parsed: parse.ParsedContent, module: str, comments: list
     return comments
 
 
-def _separate_packages(section_output: List[str], config: Config) -> List[str]:
-    group_keys: Set[str] = set()
-    comments_above: List[str] = []
-    processed_section_output: List[str] = []
+def _separate_packages(section_output: list[str], config: Config) -> list[str]:
+    group_keys: set[str] = set()
+    comments_above: list[str] = []
+    processed_section_output: list[str] = []
 
     for section_line in section_output:
         if section_line.startswith("#"):

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -191,7 +191,7 @@ class _Config:
     force_sort_within_sections: bool = False
     lexicographical: bool = False
     group_by_package: bool = False
-    separate_packages: FrozenSet[str] = frozenset()
+    separate_packages: frozenset[str] = frozenset()
     ignore_whitespace: bool = False
     no_lines_before: frozenset[str] = frozenset()
     no_inline_sort: bool = False


### PR DESCRIPTION
[Upstream](https://github.com/PyCQA/isort/releases/tag/6.0.0) has dropped support for Python 3.8 (and 3.9) now - update types accordingly.